### PR TITLE
Added GICutscenes.bat

### DIFF
--- a/GICutscenes.bat
+++ b/GICutscenes.bat
@@ -1,0 +1,33 @@
+@echo off
+
+rem Getting the USM file
+echo Drag and drop your USM file here, or enter the path manually:
+set /p file="Enter the path to the file: "
+set "filePath=%file:"=%"
+GICutscenes demuxUsm "%filePath%" -m -s
+
+echo ----------------------------------------------------
+echo %filePath%
+echo %file%
+echo ----------------------------------------------------
+
+
+rem Extracting file name without extension
+for %%I in ("%filePath%") do (
+    set "fileName=%%~nI"
+)
+
+echo ----------------------------------------------------
+echo %fileName%
+echo ----------------------------------------------------
+
+rem Extracting subtitles
+mkdir "./output/subs" 2>nul
+ffmpeg -i "./output/%fileName%.mkv" -map 0:s:0 "./output/subs/%fileName%.ass"
+
+echo ----------------------------------------------------
+echo ----------------------------------------------------
+
+ffmpeg -i "./output/%fileName%.mkv" -i "./output/subs/%fileName%.ass" -map 0:0 -map 0:2 -c:v libx264 -crf 18 -c:a copy -preset veryfast -vf "ass=./output/subs/%fileName%.ass" "./output/%fileName%.mp4"
+
+pause


### PR DESCRIPTION
This is a batch file that takes in the `.usm` file (either through drag and drop, or manually typing), then generates an `.mkv` file of the cutscene. It then extracts the subtitles and generates an `.mp4` file along with Hard Subs. 

- `ffmpeg.exe` is required. Get it from [here](https://github.com/BtbN/FFmpeg-Builds/releases). Make sure it's `ffmpeg-master-latest-win64-gpl.zip`
- [GenshinData](https://gitlab.com/Dimbreath/AnimeGameData) folder is required.